### PR TITLE
Implemented sub pipeline executor.

### DIFF
--- a/ecs.cpp
+++ b/ecs.cpp
@@ -96,7 +96,7 @@ StringName ECS::get_resource_name(godex::resource_id p_resource_id) {
 
 // Undefine the macro defined into `ecs.h` so we can define the method properly.
 #undef register_system
-void ECS::register_system(get_system_exec_info_func p_get_info_func, StringName p_name, String p_description) {
+void ECS::register_system(func_get_system_exe_info p_func_get_exe_info, StringName p_name, String p_description) {
 	{
 		const uint32_t id = get_system_id(p_name);
 		ERR_FAIL_COND_MSG(id != UINT32_MAX, "The system is already registered.");
@@ -106,7 +106,7 @@ void ECS::register_system(get_system_exec_info_func p_get_info_func, StringName 
 	systems.push_back(p_name);
 	systems_info.push_back({ p_description,
 			UINT32_MAX,
-			p_get_info_func });
+			p_func_get_exe_info });
 
 	print_line("System: " + p_name + " registered with ID: " + itos(id));
 }
@@ -127,7 +127,7 @@ godex::system_id ECS::register_dynamic_system(StringName p_name, const godex::Dy
 	systems.push_back(p_name);
 	systems_info.push_back({ "Script system",
 			dynamic_system_id,
-			godex::get_dynamic_system_get_exec_info(dynamic_system_id) });
+			godex::get_func_dynamic_system_exec_info(dynamic_system_id) });
 
 	print_line("Dynamic system: " + p_name + " registered with ID: " + itos(id));
 
@@ -143,7 +143,7 @@ uint32_t ECS::get_systems_count() {
 	return systems.size();
 }
 
-get_system_exec_info_func ECS::get_func_system_exe_info(godex::system_id p_id) {
+func_get_system_exe_info ECS::get_func_system_exe_info(godex::system_id p_id) {
 	ERR_FAIL_INDEX_V_MSG(p_id, systems_info.size(), nullptr, "The SystemID: " + itos(p_id) + " doesn't exists.");
 	return systems_info[p_id].exec_info;
 }

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -105,6 +105,7 @@ void ECS::register_system(get_system_exec_info_func p_get_info_func, StringName 
 	const godex::system_id id = systems.size();
 	systems.push_back(p_name);
 	systems_info.push_back({ p_description,
+			UINT32_MAX,
 			p_get_info_func });
 
 	print_line("System: " + p_name + " registered with ID: " + itos(id));
@@ -125,7 +126,8 @@ godex::system_id ECS::register_dynamic_system(StringName p_name, const godex::Dy
 
 	systems.push_back(p_name);
 	systems_info.push_back({ "Script system",
-			godex::get_dynamic_system_get_info(dynamic_system_id) });
+			dynamic_system_id,
+			godex::get_dynamic_system_get_exec_info(dynamic_system_id) });
 
 	print_line("Dynamic system: " + p_name + " registered with ID: " + itos(id));
 
@@ -158,8 +160,9 @@ String ECS::get_system_desc(godex::system_id p_id) {
 
 void ECS::set_dynamic_system_target(godex::system_id p_id, Object *p_target) {
 	ERR_FAIL_COND_MSG(verify_system_id(p_id) == false, "This system " + itos(p_id) + " doesn't exists.");
-	//ERR_FAIL_COND_MSG(systems_info[p_id]);
-	ERR_FAIL_MSG("TODO finish this function.");
+	ERR_FAIL_COND_MSG(systems_info[p_id].dynamic_system_id == UINT32_MAX, "The system " + itos(p_id) + " is not a dynamic system.");
+	godex::DynamicSystemInfo *info = godex::get_dynamic_system_info(systems_info[p_id].dynamic_system_id);
+	info->set_target(p_target);
 }
 
 bool ECS::verify_system_id(godex::system_id p_id) {

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -143,7 +143,12 @@ uint32_t ECS::get_systems_count() {
 	return systems.size();
 }
 
-SystemExeInfo ECS::get_system_info(godex::system_id p_id) {
+get_system_exec_info_func ECS::get_func_system_exe_info(godex::system_id p_id) {
+	ERR_FAIL_INDEX_V_MSG(p_id, systems_info.size(), nullptr, "The SystemID: " + itos(p_id) + " doesn't exists.");
+	return systems_info[p_id].exec_info;
+}
+
+SystemExeInfo ECS::get_system_exe_info(godex::system_id p_id) {
 	ERR_FAIL_INDEX_V_MSG(p_id, systems_info.size(), SystemExeInfo(), "The SystemID: " + itos(p_id) + " doesn't exists.");
 	return systems_info[p_id].exec_info();
 }

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -98,7 +98,7 @@ StringName ECS::get_resource_name(godex::resource_id p_resource_id) {
 #undef register_system
 void ECS::register_system(get_system_exec_info_func p_get_info_func, StringName p_name, String p_description) {
 	{
-		const uint32_t id = find_system_id(p_name);
+		const uint32_t id = get_system_id(p_name);
 		ERR_FAIL_COND_MSG(id != UINT32_MAX, "The system is already registered.");
 	}
 
@@ -114,7 +114,7 @@ void ECS::register_system(get_system_exec_info_func p_get_info_func, StringName 
 godex::system_id ECS::register_dynamic_system(StringName p_name, const godex::DynamicSystemInfo *p_info) {
 	ERR_FAIL_COND_V_MSG(p_info == nullptr, UINT32_MAX, "`DynamicSysteInfo` can't be nullptr.");
 	{
-		const uint32_t id = find_system_id(p_name);
+		const uint32_t id = get_system_id(p_name);
 		ERR_FAIL_COND_V_MSG(id != UINT32_MAX, UINT32_MAX, "The system is already registered.");
 	}
 
@@ -134,7 +134,7 @@ godex::system_id ECS::register_dynamic_system(StringName p_name, const godex::Dy
 	return id;
 }
 
-godex::system_id ECS::find_system_id(StringName p_name) {
+godex::system_id ECS::get_system_id(const StringName &p_name) {
 	const int64_t index = systems.find(p_name);
 	return index >= 0 ? godex::system_id(index) : UINT32_MAX;
 }

--- a/ecs.cpp
+++ b/ecs.cpp
@@ -148,9 +148,9 @@ get_system_exec_info_func ECS::get_func_system_exe_info(godex::system_id p_id) {
 	return systems_info[p_id].exec_info;
 }
 
-SystemExeInfo ECS::get_system_exe_info(godex::system_id p_id) {
-	ERR_FAIL_INDEX_V_MSG(p_id, systems_info.size(), SystemExeInfo(), "The SystemID: " + itos(p_id) + " doesn't exists.");
-	return systems_info[p_id].exec_info();
+void ECS::get_system_exe_info(godex::system_id p_id, SystemExeInfo &r_info) {
+	ERR_FAIL_INDEX_MSG(p_id, systems_info.size(), "The SystemID: " + itos(p_id) + " doesn't exists.");
+	return systems_info[p_id].exec_info(r_info);
 }
 
 StringName ECS::get_system_name(godex::system_id p_id) {

--- a/ecs.h
+++ b/ecs.h
@@ -37,6 +37,7 @@ struct ResourceInfo {
 
 struct SystemInfo {
 	String description;
+	uint32_t dynamic_system_id = UINT32_MAX;
 	get_system_exec_info_func exec_info;
 };
 

--- a/ecs.h
+++ b/ecs.h
@@ -35,6 +35,11 @@ struct ResourceInfo {
 	godex::Resource *(*create_resource)();
 };
 
+struct SystemInfo {
+	String description;
+	get_system_exec_info_func exec_info;
+};
+
 class ECS : public Object {
 	GDCLASS(ECS, Object)
 
@@ -83,30 +88,32 @@ public:
 	static StringName get_resource_name(godex::resource_id p_resource_id);
 
 	// ~~ Systems ~~
-	static void register_system(get_system_info_func p_get_info_func, StringName p_name, String p_description = "");
+	static void register_system(get_system_exec_info_func p_get_info_func, StringName p_name, String p_description = "");
 
 	// Register the system and returns the ID.
 	static godex::system_id register_dynamic_system(StringName p_name, const godex::DynamicSystemInfo *p_info);
 
-// This macro save the user the need to pass a `SystemInfo`, indeed it wraps
-// the passed function with a labda function that creates a `SystemInfo`.
-// By defining the same name of the method, the IDE autocomplete shows the method
-// name `register_system`, properly + it's impossible use the function directly
-// by mistake.
-#define register_system(func, name, desc)                                  \
-	register_system([]() -> SystemInfo {                                   \
-		SystemInfo i = SystemBuilder::get_system_info_from_function(func); \
-		i.system_func = [](World *p_world) {                               \
-			SystemBuilder::system_exec_func(p_world, func);                \
-		};                                                                 \
-		return i;                                                          \
-	},                                                                     \
+// This macro save the user the need to pass a `SystemExeInfo`, indeed it wraps
+// the passed function with a labda function that creates a `SystemExeInfo`.
+// By defining the same name of the method, the IDE autocomplete shows the
+// method name `register_system`, properly + it's impossible use the function
+// directly by mistake.
+#define register_system(func, name, desc)                                     \
+	register_system([]() -> SystemExeInfo {                                   \
+		SystemExeInfo i = SystemBuilder::get_system_info_from_function(func); \
+		i.system_func = [](World *p_world) {                                  \
+			SystemBuilder::system_exec_func(p_world, func);                   \
+		};                                                                    \
+		return i;                                                             \
+	},                                                                        \
 			name, desc)
 
 	/// Returns the system id or UINT32_MAX if not found.
 	static godex::system_id find_system_id(StringName p_name);
 	static uint32_t get_systems_count();
-	static const SystemInfo &get_system_info(godex::system_id p_id);
+	static SystemExeInfo get_system_info(godex::system_id p_id);
+	static StringName get_system_name(godex::system_id p_id);
+	static String get_system_desc(godex::system_id p_id);
 	static void set_dynamic_system_target(godex::system_id p_id, Object *p_target);
 	static bool verify_system_id(godex::system_id p_id);
 

--- a/ecs.h
+++ b/ecs.h
@@ -109,7 +109,7 @@ public:
 			name, desc)
 
 	/// Returns the system id or UINT32_MAX if not found.
-	static godex::system_id find_system_id(StringName p_name); // TODO rename to `get_system_id`.
+	static godex::system_id get_system_id(const StringName &p_name);
 	static uint32_t get_systems_count();
 	/// Returns the function that can be used to obtain the `SystemExeInfo`.
 	static get_system_exec_info_func get_func_system_exe_info(godex::system_id p_id);

--- a/ecs.h
+++ b/ecs.h
@@ -99,21 +99,22 @@ public:
 // By defining the same name of the method, the IDE autocomplete shows the
 // method name `register_system`, properly + it's impossible use the function
 // directly by mistake.
-#define register_system(func, name, desc)                                     \
-	register_system([]() -> SystemExeInfo {                                   \
-		SystemExeInfo i = SystemBuilder::get_system_info_from_function(func); \
-		i.system_func = [](World *p_world) {                                  \
-			SystemBuilder::system_exec_func(p_world, func);                   \
-		};                                                                    \
-		return i;                                                             \
-	},                                                                        \
+#define register_system(func, name, desc)                           \
+	register_system([](SystemExeInfo &r_info) {                     \
+		SystemBuilder::get_system_info_from_function(r_info, func); \
+		r_info.system_func = [](World *p_world) {                   \
+			SystemBuilder::system_exec_func(p_world, func);         \
+		};                                                          \
+	},                                                              \
 			name, desc)
 
 	/// Returns the system id or UINT32_MAX if not found.
-	static godex::system_id find_system_id(StringName p_name);
+	static godex::system_id find_system_id(StringName p_name); // TODO rename to `get_system_id`.
 	static uint32_t get_systems_count();
+	/// Returns the function that can be used to obtain the `SystemExeInfo`.
 	static get_system_exec_info_func get_func_system_exe_info(godex::system_id p_id);
-	static SystemExeInfo get_system_exe_info(godex::system_id p_id);
+	/// Returns the `SystemExeInfo`.
+	static void get_system_exe_info(godex::system_id p_id, SystemExeInfo &r_info);
 	static StringName get_system_name(godex::system_id p_id);
 	static String get_system_desc(godex::system_id p_id);
 	static void set_dynamic_system_target(godex::system_id p_id, Object *p_target);

--- a/ecs.h
+++ b/ecs.h
@@ -38,7 +38,7 @@ struct ResourceInfo {
 struct SystemInfo {
 	String description;
 	uint32_t dynamic_system_id = UINT32_MAX;
-	get_system_exec_info_func exec_info;
+	func_get_system_exe_info exec_info;
 };
 
 class ECS : public Object {
@@ -89,7 +89,7 @@ public:
 	static StringName get_resource_name(godex::resource_id p_resource_id);
 
 	// ~~ Systems ~~
-	static void register_system(get_system_exec_info_func p_get_info_func, StringName p_name, String p_description = "");
+	static void register_system(func_get_system_exe_info p_func_get_exe_info, StringName p_name, String p_description = "");
 
 	// Register the system and returns the ID.
 	static godex::system_id register_dynamic_system(StringName p_name, const godex::DynamicSystemInfo *p_info);
@@ -112,7 +112,7 @@ public:
 	static godex::system_id get_system_id(const StringName &p_name);
 	static uint32_t get_systems_count();
 	/// Returns the function that can be used to obtain the `SystemExeInfo`.
-	static get_system_exec_info_func get_func_system_exe_info(godex::system_id p_id);
+	static func_get_system_exe_info get_func_system_exe_info(godex::system_id p_id);
 	/// Returns the `SystemExeInfo`.
 	static void get_system_exe_info(godex::system_id p_id, SystemExeInfo &r_info);
 	static StringName get_system_name(godex::system_id p_id);

--- a/ecs.h
+++ b/ecs.h
@@ -112,7 +112,8 @@ public:
 	/// Returns the system id or UINT32_MAX if not found.
 	static godex::system_id find_system_id(StringName p_name);
 	static uint32_t get_systems_count();
-	static SystemExeInfo get_system_info(godex::system_id p_id);
+	static get_system_exec_info_func get_func_system_exe_info(godex::system_id p_id);
+	static SystemExeInfo get_system_exe_info(godex::system_id p_id);
 	static StringName get_system_name(godex::system_id p_id);
 	static String get_system_desc(godex::system_id p_id);
 	static void set_dynamic_system_target(godex::system_id p_id, Object *p_target);

--- a/editor_plugins/editor_world_ecs.cpp
+++ b/editor_plugins/editor_world_ecs.cpp
@@ -647,7 +647,8 @@ void EditorWorldECS::pipeline_panel_update() {
 			if (system_id == UINT32_MAX) {
 				info_box->set_system_name(system_name, false);
 			} else {
-				const SystemExeInfo system_exec_info = ECS::get_system_exe_info(system_id);
+				SystemExeInfo system_exec_info;
+				ECS::get_system_exe_info(system_id, system_exec_info);
 				const StringName key_name = ECS::get_system_name(system_id);
 
 				info_box->set_system_name(key_name);

--- a/editor_plugins/editor_world_ecs.cpp
+++ b/editor_plugins/editor_world_ecs.cpp
@@ -647,35 +647,36 @@ void EditorWorldECS::pipeline_panel_update() {
 			if (system_id == UINT32_MAX) {
 				info_box->set_system_name(system_name, false);
 			} else {
-				const SystemInfo &system_info = ECS::get_system_info(system_id);
+				const SystemExeInfo system_exec_info = ECS::get_system_info(system_id);
+				const StringName key_name = ECS::get_system_name(system_id);
 
-				info_box->set_system_name(system_info.name);
+				info_box->set_system_name(key_name);
 
 				// Draw immutable components.
-				for (uint32_t u = 0; u < system_info.immutable_components.size(); u += 1) {
+				for (uint32_t u = 0; u < system_exec_info.immutable_components.size(); u += 1) {
 					info_box->add_system_element(
-							ECS::get_component_name(system_info.immutable_components[u]),
+							ECS::get_component_name(system_exec_info.immutable_components[u]),
 							false);
 				}
 
 				// Draw mutable components.
-				for (uint32_t u = 0; u < system_info.mutable_components.size(); u += 1) {
+				for (uint32_t u = 0; u < system_exec_info.mutable_components.size(); u += 1) {
 					info_box->add_system_element(
-							ECS::get_component_name(system_info.mutable_components[u]),
+							ECS::get_component_name(system_exec_info.mutable_components[u]),
 							true);
 				}
 
 				// Draw immutable resources.
-				for (uint32_t u = 0; u < system_info.immutable_resources.size(); u += 1) {
+				for (uint32_t u = 0; u < system_exec_info.immutable_resources.size(); u += 1) {
 					info_box->add_system_element(
-							String(ECS::get_resource_name(system_info.immutable_resources[u])) + " [res]",
+							String(ECS::get_resource_name(system_exec_info.immutable_resources[u])) + " [res]",
 							false);
 				}
 
 				// Draw immutable resources.
-				for (uint32_t u = 0; u < system_info.mutable_resources.size(); u += 1) {
+				for (uint32_t u = 0; u < system_exec_info.mutable_resources.size(); u += 1) {
 					info_box->add_system_element(
-							String(ECS::get_resource_name(system_info.mutable_resources[u])) + " [res]",
+							String(ECS::get_resource_name(system_exec_info.mutable_resources[u])) + " [res]",
 							true);
 				}
 			}
@@ -738,9 +739,10 @@ void EditorWorldECS::add_sys_update(const String &p_search) {
 	TreeItem *native_root = nullptr;
 
 	for (uint32_t i = 0; i < ECS::get_systems_count(); i += 1) {
-		const SystemInfo &info = ECS::get_system_info(i);
+		const StringName key_name = ECS::get_system_name(i);
+		const String desc = ECS::get_system_desc(i);
 
-		const String name(String(info.name).to_lower());
+		const String name(String(key_name).to_lower());
 		if (search.empty() == false && name.find(search) != 0) {
 			// System filtered.
 			continue;
@@ -755,9 +757,9 @@ void EditorWorldECS::add_sys_update(const String &p_search) {
 		}
 
 		TreeItem *item = add_sys_tree->create_item(native_root);
-		item->set_text(0, info.name);
-		item->set_meta("system_name", info.name);
-		item->set_meta("desc", info.description);
+		item->set_text(0, name);
+		item->set_meta("system_name", key_name);
+		item->set_meta("desc", desc);
 	}
 
 	// Scripts systems

--- a/editor_plugins/editor_world_ecs.cpp
+++ b/editor_plugins/editor_world_ecs.cpp
@@ -647,7 +647,7 @@ void EditorWorldECS::pipeline_panel_update() {
 			if (system_id == UINT32_MAX) {
 				info_box->set_system_name(system_name, false);
 			} else {
-				const SystemExeInfo system_exec_info = ECS::get_system_info(system_id);
+				const SystemExeInfo system_exec_info = ECS::get_system_exe_info(system_id);
 				const StringName key_name = ECS::get_system_name(system_id);
 
 				info_box->set_system_name(key_name);

--- a/editor_plugins/editor_world_ecs.cpp
+++ b/editor_plugins/editor_world_ecs.cpp
@@ -643,7 +643,7 @@ void EditorWorldECS::pipeline_panel_update() {
 
 		} else {
 			// Init a native system.
-			const uint32_t system_id = ECS::find_system_id(system_name);
+			const uint32_t system_id = ECS::get_system_id(system_name);
 			if (system_id == UINT32_MAX) {
 				info_box->set_system_name(system_name, false);
 			} else {

--- a/iterators/dynamic_query.cpp
+++ b/iterators/dynamic_query.cpp
@@ -152,7 +152,7 @@ void DynamicQuery::end() {
 	storages.clear();
 }
 
-void DynamicQuery::get_system_info(SystemInfo &p_info) const {
+void DynamicQuery::get_system_info(SystemExeInfo &p_info) const {
 	ERR_FAIL_COND(is_valid() == false);
 	for (uint32_t i = 0; i < component_ids.size(); i += 1) {
 		if (mutability[i]) {

--- a/iterators/dynamic_query.h
+++ b/iterators/dynamic_query.h
@@ -76,7 +76,7 @@ public:
 	/// Ends the query execution.
 	void end();
 
-	void get_system_info(SystemInfo &p_info) const;
+	void get_system_info(SystemExeInfo &p_info) const;
 
 private:
 	bool has_entity(EntityID p_id) const;

--- a/methods_ecs.py
+++ b/methods_ecs.py
@@ -34,7 +34,7 @@ def generate_dynamic_system_funcs():
 
     # Write the array that olds the function pointers.
     f.write("\n")
-    f.write("get_system_exec_info_func dynamic_systems_get_info_ptr[DYNAMIC_SYSTEMS_MAX] = {\n")
+    f.write("func_get_system_exe_info func_get_dynamic_systems_exe_info_ptr[DYNAMIC_SYSTEMS_MAX] = {\n")
     for i in range(max_dynamic_systems):
         if i > 0:
             f.write(", ")
@@ -42,7 +42,7 @@ def generate_dynamic_system_funcs():
     f.write("};\n")
 
     f.write("\n")
-    f.write("system_execute dynamic_systems_ptr[DYNAMIC_SYSTEMS_MAX] = {\n")
+    f.write("func_system_execute dynamic_systems_ptr[DYNAMIC_SYSTEMS_MAX] = {\n")
     for i in range(max_dynamic_systems):
         if i > 0:
             f.write(", ")
@@ -58,9 +58,9 @@ def generate_dynamic_system_funcs():
     f.write("}\n")
 
     f.write("\n")
-    f.write("get_system_exec_info_func godex::get_dynamic_system_get_exec_info(uint32_t p_id){\n")
+    f.write("func_get_system_exe_info godex::get_func_dynamic_system_exec_info(uint32_t p_id){\n")
     f.write("	CRASH_COND_MSG(p_id >= DYNAMIC_SYSTEMS_MAX, \"The ID \" + itos(p_id) + \" is out of bounds \" + itos(DYNAMIC_SYSTEMS_MAX) + \". Please open an issue so we can increase this limit.\");\n")
-    f.write("	return dynamic_systems_get_info_ptr[p_id];\n")
+    f.write("	return func_get_dynamic_systems_exe_info_ptr[p_id];\n")
     f.write("}\n")
 
     f.write("\n")

--- a/methods_ecs.py
+++ b/methods_ecs.py
@@ -28,8 +28,8 @@ def generate_dynamic_system_funcs():
         f.write("	godex::DynamicSystemInfo::executor(p_world, dynamic_info[" + str(i) + "]);\n")
         f.write("}\n")
         f.write("\n")
-        f.write("SystemExeInfo dynamic_system_get_info_internal_" + str(i) + "() {\n")
-        f.write("	return godex::DynamicSystemInfo::get_info(dynamic_info[" + str(i) + "], dynamic_system_exec_internal_"+str(i)+");\n")
+        f.write("void dynamic_system_get_info_internal_" + str(i) + "(SystemExeInfo& r_info) {\n")
+        f.write("	godex::DynamicSystemInfo::get_info(dynamic_info[" + str(i) + "], dynamic_system_exec_internal_"+str(i)+", r_info);\n")
         f.write("}\n")
 
     # Write the array that olds the function pointers.

--- a/methods_ecs.py
+++ b/methods_ecs.py
@@ -58,9 +58,15 @@ def generate_dynamic_system_funcs():
     f.write("}\n")
 
     f.write("\n")
-    f.write("get_system_exec_info_func godex::get_dynamic_system_get_info(uint32_t p_id){\n")
+    f.write("get_system_exec_info_func godex::get_dynamic_system_get_exec_info(uint32_t p_id){\n")
     f.write("	CRASH_COND_MSG(p_id >= DYNAMIC_SYSTEMS_MAX, \"The ID \" + itos(p_id) + \" is out of bounds \" + itos(DYNAMIC_SYSTEMS_MAX) + \". Please open an issue so we can increase this limit.\");\n")
     f.write("	return dynamic_systems_get_info_ptr[p_id];\n")
+    f.write("}\n")
+
+    f.write("\n")
+    f.write("godex::DynamicSystemInfo* godex::get_dynamic_system_info(uint32_t p_id){\n")
+    f.write("	CRASH_COND_MSG(p_id >= DYNAMIC_SYSTEMS_MAX, \"The ID \" + itos(p_id) + \" is out of bounds \" + itos(DYNAMIC_SYSTEMS_MAX) + \". Please open an issue so we can increase this limit.\");\n")
+    f.write("	return &dynamic_info[p_id];\n")
     f.write("}\n")
 
     f.close()

--- a/nodes/ecs_world.cpp
+++ b/nodes/ecs_world.cpp
@@ -86,7 +86,7 @@ Pipeline *PipelineECS::get_pipeline() {
 		const StringName system_name = systems_name[i];
 		const godex::system_id id = ECS::find_system_id(system_name);
 		ERR_CONTINUE_MSG(id == UINT32_MAX, "The system " + system_name + " was not found.");
-		pipeline->add_registered_system(ECS::get_system_info(id));
+		pipeline->add_registered_system(id);
 	}
 
 	return pipeline;

--- a/nodes/ecs_world.cpp
+++ b/nodes/ecs_world.cpp
@@ -84,7 +84,7 @@ Pipeline *PipelineECS::get_pipeline() {
 
 	for (int i = 0; i < systems_name.size(); i += 1) {
 		const StringName system_name = systems_name[i];
-		const godex::system_id id = ECS::find_system_id(system_name);
+		const godex::system_id id = ECS::get_system_id(system_name);
 		ERR_CONTINUE_MSG(id == UINT32_MAX, "The system " + system_name + " was not found.");
 		pipeline->add_registered_system(id);
 	}

--- a/pipeline/pipeline.cpp
+++ b/pipeline/pipeline.cpp
@@ -33,13 +33,17 @@ void Pipeline::build() {
 
 	systems.reserve(systems_info.size());
 
+	SystemExeInfo info;
 	for (uint32_t i = 0; i < systems_info.size(); i += 1) {
-		const SystemExeInfo info = systems_info[i]();
+		info.clear();
+		systems_info[i](info);
+
 #ifdef DEBUG_ENABLED
 		// This is automated by the `add_system` macro or by
 		// `ECS::register_system` macro, so is never supposed to happen.
 		CRASH_COND_MSG(info.system_func == nullptr, "At this point `info.system_func` is supposed to be not null. To add a system use the following syntax: `add_system(function_name);` or use the `ECS` class to get the `SystemExeInfo` if it's a registered system.");
 #endif
+
 		systems.push_back(info.system_func);
 	}
 }
@@ -49,8 +53,11 @@ bool Pipeline::is_ready() const {
 }
 
 void Pipeline::get_systems_dependencies(SystemExeInfo &p_info) const {
+	SystemExeInfo other_info;
 	for (uint32_t i = 0; i < systems_info.size(); i += 1) {
-		const SystemExeInfo other_info = systems_info[i]();
+		other_info.clear();
+
+		systems_info[i](other_info);
 
 		// Handles the Components.
 		for (uint32_t t = 0; t < other_info.immutable_components.size(); t += 1) {

--- a/pipeline/pipeline.cpp
+++ b/pipeline/pipeline.cpp
@@ -5,8 +5,8 @@
 Pipeline::Pipeline() {
 }
 
-void Pipeline::add_registered_system(const SystemInfo &p_system_info) {
-	CRASH_COND_MSG(p_system_info.system_func == nullptr, "At this point `info.system_func` is supposed to be not null. To add a system use the following syntax: `add_system(function_name);` or use the `ECS` class to get the `SystemInfo` if it's a registered system.");
+void Pipeline::add_registered_system(const SystemExeInfo &p_system_info) {
+	CRASH_COND_MSG(p_system_info.system_func == nullptr, "At this point `info.system_func` is supposed to be not null. To add a system use the following syntax: `add_system(function_name);` or use the `ECS` class to get the `SystemExeInfo` if it's a registered system.");
 	//print_line(
 	//		"Added function that has " + itos(info.mutable_components.size()) +
 	//		" mut comp, " + itos(info.immutable_components.size()) + " immutable comp");
@@ -18,8 +18,8 @@ void Pipeline::add_registered_system(const SystemInfo &p_system_info) {
 // Unset the macro defined into the `pipeline.h` so to properly point the method
 // definition.
 #undef add_system
-void Pipeline::add_system(get_system_info_func p_get_info_func) {
-	const SystemInfo info = p_get_info_func();
+void Pipeline::add_system(get_system_exec_info_func p_get_info_func) {
+	const SystemExeInfo info = p_get_info_func();
 	add_registered_system(info);
 }
 

--- a/pipeline/pipeline.cpp
+++ b/pipeline/pipeline.cpp
@@ -9,16 +9,16 @@ Pipeline::Pipeline() {
 // Unset the macro defined into the `pipeline.h` so to properly point the method
 // definition.
 #undef add_system
-void Pipeline::add_system(get_system_exec_info_func p_get_info_func) {
+void Pipeline::add_system(func_get_system_exe_info p_func_get_exe_info) {
 #ifdef DEBUG_ENABLED
 	// This is automated by the `add_system` macro or by
 	// `ECS::register_system` macro, so is never supposed to happen.
-	CRASH_COND_MSG(p_get_info_func == nullptr, "The passed system constructor can't be nullptr at this point.");
+	CRASH_COND_MSG(p_func_get_exe_info == nullptr, "The passed system constructor can't be nullptr at this point.");
 	// Using crash cond because pipeline composition is not directly exposed
 	// to the user.
 	CRASH_COND_MSG(is_ready(), "The pipeline is ready, you can't modify it.");
 #endif
-	systems_info.push_back(p_get_info_func);
+	systems_info.push_back(p_func_get_exe_info);
 }
 
 void Pipeline::add_registered_system(godex::system_id p_id) {
@@ -31,7 +31,7 @@ void Pipeline::build() {
 #endif
 	ready = true;
 
-	systems.reserve(systems_info.size());
+	systems_exe.reserve(systems_info.size());
 
 	SystemExeInfo info;
 	for (uint32_t i = 0; i < systems_info.size(); i += 1) {
@@ -44,7 +44,7 @@ void Pipeline::build() {
 		CRASH_COND_MSG(info.system_func == nullptr, "At this point `info.system_func` is supposed to be not null. To add a system use the following syntax: `add_system(function_name);` or use the `ECS` class to get the `SystemExeInfo` if it's a registered system.");
 #endif
 
-		systems.push_back(info.system_func);
+		systems_exe.push_back(info.system_func);
 	}
 }
 
@@ -101,7 +101,7 @@ void Pipeline::get_systems_dependencies(SystemExeInfo &p_info) const {
 
 void Pipeline::reset() {
 	systems_info.clear();
-	systems.clear();
+	systems_exe.clear();
 	ready = false;
 }
 
@@ -109,7 +109,7 @@ void Pipeline::dispatch(World *p_world) {
 #ifdef DEBUG_ENABLED
 	CRASH_COND_MSG(ready == false, "You can't dispatch a pipeline which is not yet builded. Please call `build`.");
 #endif
-	for (uint32_t i = 0; i < systems.size(); i += 1) {
-		systems[i](p_world);
+	for (uint32_t i = 0; i < systems_exe.size(); i += 1) {
+		systems_exe[i](p_world);
 	}
 }

--- a/pipeline/pipeline.cpp
+++ b/pipeline/pipeline.cpp
@@ -1,29 +1,107 @@
 #include "pipeline.h"
 
+#include "../ecs.h"
 #include "../world/world.h"
 
 Pipeline::Pipeline() {
-}
-
-void Pipeline::add_registered_system(const SystemExeInfo &p_system_info) {
-	CRASH_COND_MSG(p_system_info.system_func == nullptr, "At this point `info.system_func` is supposed to be not null. To add a system use the following syntax: `add_system(function_name);` or use the `ECS` class to get the `SystemExeInfo` if it's a registered system.");
-	//print_line(
-	//		"Added function that has " + itos(info.mutable_components.size()) +
-	//		" mut comp, " + itos(info.immutable_components.size()) + " immutable comp");
-
-	// TODO compose the pipeline
-	systems.push_back(p_system_info.system_func);
 }
 
 // Unset the macro defined into the `pipeline.h` so to properly point the method
 // definition.
 #undef add_system
 void Pipeline::add_system(get_system_exec_info_func p_get_info_func) {
-	const SystemExeInfo info = p_get_info_func();
-	add_registered_system(info);
+#ifdef DEBUG_ENABLED
+	// This is automated by the `add_system` macro or by
+	// `ECS::register_system` macro, so is never supposed to happen.
+	CRASH_COND_MSG(p_get_info_func == nullptr, "The passed system constructor can't be nullptr at this point.");
+	// Using crash cond because pipeline composition is not directly exposed
+	// to the user.
+	CRASH_COND_MSG(is_ready(), "The pipeline is ready, you can't modify it.");
+#endif
+	systems_info.push_back(p_get_info_func);
+}
+
+void Pipeline::add_registered_system(godex::system_id p_id) {
+	add_system(ECS::get_func_system_exe_info(p_id));
+}
+
+void Pipeline::build() {
+#ifdef DEBUG_ENABLED
+	CRASH_COND_MSG(ready, "You can't build a pipeline twice.");
+#endif
+	ready = true;
+
+	systems.reserve(systems_info.size());
+
+	for (uint32_t i = 0; i < systems_info.size(); i += 1) {
+		const SystemExeInfo info = systems_info[i]();
+#ifdef DEBUG_ENABLED
+		// This is automated by the `add_system` macro or by
+		// `ECS::register_system` macro, so is never supposed to happen.
+		CRASH_COND_MSG(info.system_func == nullptr, "At this point `info.system_func` is supposed to be not null. To add a system use the following syntax: `add_system(function_name);` or use the `ECS` class to get the `SystemExeInfo` if it's a registered system.");
+#endif
+		systems.push_back(info.system_func);
+	}
+}
+
+bool Pipeline::is_ready() const {
+	return ready;
+}
+
+void Pipeline::get_systems_dependencies(SystemExeInfo &p_info) const {
+	for (uint32_t i = 0; i < systems_info.size(); i += 1) {
+		const SystemExeInfo other_info = systems_info[i]();
+
+		// Handles the Components.
+		for (uint32_t t = 0; t < other_info.immutable_components.size(); t += 1) {
+			const godex::component_id id = other_info.immutable_components[t];
+
+			const bool is_unique = p_info.immutable_components.find(id) == -1;
+			if (is_unique) {
+				p_info.immutable_components.push_back(id);
+			}
+		}
+
+		for (uint32_t t = 0; t < other_info.mutable_components.size(); t += 1) {
+			const godex::component_id id = other_info.mutable_components[t];
+
+			const bool is_unique = p_info.mutable_components.find(id) == -1;
+			if (is_unique) {
+				p_info.mutable_components.push_back(id);
+			}
+		}
+
+		// Handles the Resources.
+		for (uint32_t t = 0; t < other_info.immutable_resources.size(); t += 1) {
+			const godex::resource_id id = other_info.immutable_resources[t];
+
+			const bool is_unique = p_info.immutable_resources.find(id) == -1;
+			if (is_unique) {
+				p_info.immutable_resources.push_back(id);
+			}
+		}
+
+		for (uint32_t t = 0; t < other_info.mutable_resources.size(); t += 1) {
+			const godex::resource_id id = other_info.mutable_resources[t];
+
+			const bool is_unique = p_info.mutable_resources.find(id) == -1;
+			if (is_unique) {
+				p_info.mutable_resources.push_back(id);
+			}
+		}
+	}
+}
+
+void Pipeline::reset() {
+	systems_info.clear();
+	systems.clear();
+	ready = false;
 }
 
 void Pipeline::dispatch(World *p_world) {
+#ifdef DEBUG_ENABLED
+	CRASH_COND_MSG(ready == false, "You can't dispatch a pipeline which is not yet builded. Please call `build`.");
+#endif
 	for (uint32_t i = 0; i < systems.size(); i += 1) {
 		systems[i](p_world);
 	}

--- a/pipeline/pipeline.h
+++ b/pipeline/pipeline.h
@@ -18,23 +18,23 @@ public:
 	/// Add a system that is registered via `ECS`, usually this function is used
 	/// to construct the pipeline using the `ECS` class.
 	/// This only difference with `add_system` is the argument type.
-	void add_registered_system(const SystemInfo &p_system_info);
+	void add_registered_system(const SystemExeInfo &p_system_info);
 
 	/// Add a system that is not registered via `ECS`.
-	void add_system(get_system_info_func p_get_info_func);
+	void add_system(get_system_exec_info_func p_get_info_func);
 
 	// Dispatch the pipeline on the following world.
 	void dispatch(World *p_world);
 };
 
-// This macro save the user the need to pass a `SystemInfo`, indeed it wraps
-// the passed function with a labda function that creates a `SystemInfo`.
+// This macro save the user the need to pass a `SystemExeInfo`, indeed it wraps
+// the passed function with a labda function that creates a `SystemExeInfo`.
 // By defining the same name of the method, the IDE autocomplete shows the method
 // name `add_system`, properly + it's impossible use the function directly
 // by mistake.
 #define add_system(func)                                                   \
-	add_system([]() -> SystemInfo {                                        \
-		SystemInfo i = SystemBuilder::get_system_info_from_function(func); \
+	add_system([]() -> SystemExeInfo {                                        \
+		SystemExeInfo i = SystemBuilder::get_system_info_from_function(func); \
 		i.system_func = [](World *p_world) {                               \
 			SystemBuilder::system_exec_func(p_world, func);                \
 		};                                                                 \

--- a/pipeline/pipeline.h
+++ b/pipeline/pipeline.h
@@ -4,12 +4,14 @@
 	@author AndreaCatania
 */
 
-#include "core/templates/local_vector.h"
 #include "../systems/system.h"
+#include "core/templates/local_vector.h"
 
 class World;
 
 class Pipeline {
+	bool ready = false;
+	LocalVector<get_system_exec_info_func> systems_info;
 	LocalVector<system_execute> systems;
 
 public:
@@ -18,10 +20,24 @@ public:
 	/// Add a system that is registered via `ECS`, usually this function is used
 	/// to construct the pipeline using the `ECS` class.
 	/// This only difference with `add_system` is the argument type.
-	void add_registered_system(const SystemExeInfo &p_system_info);
+	void add_registered_system(uint32_t p_id);
 
 	/// Add a system that is not registered via `ECS`.
 	void add_system(get_system_exec_info_func p_get_info_func);
+
+	/// Build the pipelines and makes it ready to dispatch.
+	/// You can't modify it anymore, after calling this.
+	void build();
+
+	/// Returns `true` if the pipeline is ready.
+	bool is_ready() const;
+
+	/// get the systems dependencies. The same `Component` or `Resource` can
+	/// be found as mutable and immutable.
+	void get_systems_dependencies(SystemExeInfo &p_info) const;
+
+	/// Reset the pipeline.
+	void reset();
 
 	// Dispatch the pipeline on the following world.
 	void dispatch(World *p_world);
@@ -32,11 +48,11 @@ public:
 // By defining the same name of the method, the IDE autocomplete shows the method
 // name `add_system`, properly + it's impossible use the function directly
 // by mistake.
-#define add_system(func)                                                   \
+#define add_system(func)                                                      \
 	add_system([]() -> SystemExeInfo {                                        \
 		SystemExeInfo i = SystemBuilder::get_system_info_from_function(func); \
-		i.system_func = [](World *p_world) {                               \
-			SystemBuilder::system_exec_func(p_world, func);                \
-		};                                                                 \
-		return i;                                                          \
+		i.system_func = [](World *p_world) {                                  \
+			SystemBuilder::system_exec_func(p_world, func);                   \
+		};                                                                    \
+		return i;                                                             \
 	})

--- a/pipeline/pipeline.h
+++ b/pipeline/pipeline.h
@@ -48,11 +48,10 @@ public:
 // By defining the same name of the method, the IDE autocomplete shows the method
 // name `add_system`, properly + it's impossible use the function directly
 // by mistake.
-#define add_system(func)                                                      \
-	add_system([]() -> SystemExeInfo {                                        \
-		SystemExeInfo i = SystemBuilder::get_system_info_from_function(func); \
-		i.system_func = [](World *p_world) {                                  \
-			SystemBuilder::system_exec_func(p_world, func);                   \
-		};                                                                    \
-		return i;                                                             \
+#define add_system(func)                                            \
+	add_system([](SystemExeInfo &r_info) {                          \
+		SystemBuilder::get_system_info_from_function(r_info, func); \
+		r_info.system_func = [](World *p_world) {                   \
+			SystemBuilder::system_exec_func(p_world, func);         \
+		};                                                          \
 	})

--- a/pipeline/pipeline.h
+++ b/pipeline/pipeline.h
@@ -11,8 +11,8 @@ class World;
 
 class Pipeline {
 	bool ready = false;
-	LocalVector<get_system_exec_info_func> systems_info;
-	LocalVector<system_execute> systems;
+	LocalVector<func_get_system_exe_info> systems_info;
+	LocalVector<func_system_execute> systems_exe;
 
 public:
 	Pipeline();
@@ -23,7 +23,7 @@ public:
 	void add_registered_system(uint32_t p_id);
 
 	/// Add a system that is not registered via `ECS`.
-	void add_system(get_system_exec_info_func p_get_info_func);
+	void add_system(func_get_system_exe_info p_func_get_exe_info);
 
 	/// Build the pipelines and makes it ready to dispatch.
 	/// You can't modify it anymore, after calling this.

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -13,11 +13,6 @@ void godex::DynamicSystemInfo::set_target(Object *p_target) {
 	target_sub_pipeline = nullptr;
 }
 
-void godex::DynamicSystemInfo::set_target(Pipeline *p_target) {
-	target_script = nullptr;
-	target_sub_pipeline = p_target;
-}
-
 void godex::DynamicSystemInfo::with_resource(uint32_t p_resource_id, bool p_mutable) {
 	const uint32_t index = resource_element_map.size() + query_element_map.size();
 	resource_element_map.push_back(index);
@@ -34,69 +29,95 @@ void godex::DynamicSystemInfo::without_component(uint32_t p_component_id) {
 	CRASH_NOW_MSG("TODO implement this please.");
 }
 
+void godex::DynamicSystemInfo::set_target(func_system_execute_pipeline p_system_exe) {
+	target_script = nullptr;
+	sub_pipeline_execute = p_system_exe;
+}
+
+void godex::DynamicSystemInfo::set_pipeline(Pipeline *p_target) {
+	CRASH_COND_MSG(sub_pipeline_execute == nullptr, "The pipeline execute target can't be nullptr at this point. Call `set_target()` before this function.");
+	target_script = nullptr;
+	target_sub_pipeline = p_target;
+}
+
 StringName godex::DynamicSystemInfo::for_each_name;
 
 void godex::DynamicSystemInfo::get_info(DynamicSystemInfo &p_info, func_system_execute p_exec, SystemExeInfo &r_out) {
-	if (p_info.target_sub_pipeline) {
-		// Sub pipeline execution.
+	// Validate.
+	if (p_info.sub_pipeline_execute) {
+		ERR_FAIL_COND_MSG(p_info.target_sub_pipeline == nullptr, "No sub pipeline set.");
+
+#ifdef DEBUG_ENABLED
 		// The pipeline must be fully build at this point
 		CRASH_COND_MSG(p_info.target_sub_pipeline->is_ready() == false, "The sub pipeline is not yet builded. Make sure to fully build it before using it as sub pipeline.");
-		// Extract all the pipeline dependencies.
-		p_info.target_sub_pipeline->get_systems_dependencies(r_out);
+#endif
+
 	} else {
 		// Script function.
 		ERR_FAIL_COND_MSG(p_info.target_script == nullptr, "[FATAL] This system doesn't have target assigned.");
 
 		// Script execution.
 		ERR_FAIL_COND(p_info.query.is_valid() == false);
+	}
 
-		for (uint32_t i = 0; i < p_info.resources.size(); i += 1) {
-			if (p_info.resources[i].is_mutable) {
-				r_out.mutable_resources.push_back(p_info.resources[i].resource_id);
-			} else {
-				r_out.immutable_resources.push_back(p_info.resources[i].resource_id);
-			}
+	// Set the resources dependencies.
+	for (uint32_t i = 0; i < p_info.resources.size(); i += 1) {
+		if (p_info.resources[i].is_mutable) {
+			r_out.mutable_resources.push_back(p_info.resources[i].resource_id);
+		} else {
+			r_out.immutable_resources.push_back(p_info.resources[i].resource_id);
 		}
+	}
 
-		p_info.query.get_system_info(r_out);
+	// Set the components dependencies.
+	p_info.query.get_system_info(r_out);
+
+	if (p_info.sub_pipeline_execute) {
+		// Extract all the pipeline dependencies.
+		p_info.target_sub_pipeline->get_systems_dependencies(r_out);
 	}
 
 	r_out.system_func = p_exec;
 }
 
 void godex::DynamicSystemInfo::executor(World *p_world, DynamicSystemInfo &p_info) {
-	// Script function.
-	ERR_FAIL_COND_MSG(p_info.target_script == nullptr, "[FATAL] This system doesn't have target assigned.");
+	if (p_info.sub_pipeline_execute) {
+		// Sub pipeline execution.
+		p_info.sub_pipeline_execute(p_world, p_info.target_sub_pipeline);
+	} else {
+		// Script function.
+		ERR_FAIL_COND_MSG(p_info.target_script == nullptr, "[FATAL] This system doesn't have target assigned.");
 
-	// Create the array where the storages are hold.
-	LocalVector<Variant> access;
-	LocalVector<Variant *> access_ptr;
-	access.resize(p_info.resource_element_map.size() + p_info.query_element_map.size());
-	access_ptr.resize(access.size());
+		// Create the array where the storages are hold.
+		LocalVector<Variant> access;
+		LocalVector<Variant *> access_ptr;
+		access.resize(p_info.resource_element_map.size() + p_info.query_element_map.size());
+		access_ptr.resize(access.size());
 
-	// First extract the resources.
-	for (uint32_t i = 0; i < p_info.resources.size(); i += 1) {
-		CRASH_NOW_MSG("TODO implement");
-		// TODO get the resource
-		//p_world->get_resource(p_info.resources[i].resource_id);
-		// TODO map to aceess
-	}
-
-	// Map the query components, so the function can be called with the
-	// right parameter order.
-	for (uint32_t c = 0; c < p_info.query.access_count(); c += 1) {
-		access[p_info.query_element_map[c]] = p_info.query.get_access(c);
-		access_ptr[p_info.query_element_map[c]] = &access[p_info.query_element_map[c]];
-	}
-
-	p_info.query.begin(p_world);
-	for (; p_info.query.is_done() == false; p_info.query.next_entity()) {
-		Callable::CallError err;
-		p_info.target_script->call(for_each_name, const_cast<const Variant **>(access_ptr.ptr()), access_ptr.size(), err);
-		if (err.error != Callable::CallError::CALL_OK) {
-			p_info.query.end();
-			ERR_FAIL_COND(err.error != Callable::CallError::CALL_OK);
+		// First extract the resources.
+		for (uint32_t i = 0; i < p_info.resources.size(); i += 1) {
+			CRASH_NOW_MSG("TODO implement");
+			// TODO get the resource
+			//p_world->get_resource(p_info.resources[i].resource_id);
+			// TODO map to aceess
 		}
+
+		// Map the query components, so the function can be called with the
+		// right parameter order.
+		for (uint32_t c = 0; c < p_info.query.access_count(); c += 1) {
+			access[p_info.query_element_map[c]] = p_info.query.get_access(c);
+			access_ptr[p_info.query_element_map[c]] = &access[p_info.query_element_map[c]];
+		}
+
+		p_info.query.begin(p_world);
+		for (; p_info.query.is_done() == false; p_info.query.next_entity()) {
+			Callable::CallError err;
+			p_info.target_script->call(for_each_name, const_cast<const Variant **>(access_ptr.ptr()), access_ptr.size(), err);
+			if (err.error != Callable::CallError::CALL_OK) {
+				p_info.query.end();
+				ERR_FAIL_COND(err.error != Callable::CallError::CALL_OK);
+			}
+		}
+		p_info.query.end();
 	}
-	p_info.query.end();
 }

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -36,35 +36,32 @@ void godex::DynamicSystemInfo::without_component(uint32_t p_component_id) {
 
 StringName godex::DynamicSystemInfo::for_each_name;
 
-SystemExeInfo godex::DynamicSystemInfo::get_info(DynamicSystemInfo &p_info, system_execute p_exec) {
-	SystemExeInfo info;
-	info.system_func = p_exec;
-
+void godex::DynamicSystemInfo::get_info(DynamicSystemInfo &p_info, system_execute p_exec, SystemExeInfo &r_out) {
 	if (p_info.target_sub_pipeline) {
 		// Sub pipeline execution.
 		// The pipeline must be fully build at this point
 		CRASH_COND_MSG(p_info.target_sub_pipeline->is_ready() == false, "The sub pipeline is not yet builded. Make sure to fully build it before using it as sub pipeline.");
 		// Extract all the pipeline dependencies.
-		p_info.target_sub_pipeline->get_systems_dependencies(info);
+		p_info.target_sub_pipeline->get_systems_dependencies(r_out);
 	} else {
 		// Script function.
-		ERR_FAIL_COND_V_MSG(p_info.target_script == nullptr, SystemExeInfo(), "[FATAL] This system doesn't have target assigned.");
+		ERR_FAIL_COND_MSG(p_info.target_script == nullptr, "[FATAL] This system doesn't have target assigned.");
 
 		// Script execution.
-		ERR_FAIL_COND_V(p_info.query.is_valid() == false, SystemExeInfo());
+		ERR_FAIL_COND(p_info.query.is_valid() == false);
 
 		for (uint32_t i = 0; i < p_info.resources.size(); i += 1) {
 			if (p_info.resources[i].is_mutable) {
-				info.mutable_resources.push_back(p_info.resources[i].resource_id);
+				r_out.mutable_resources.push_back(p_info.resources[i].resource_id);
 			} else {
-				info.immutable_resources.push_back(p_info.resources[i].resource_id);
+				r_out.immutable_resources.push_back(p_info.resources[i].resource_id);
 			}
 		}
 
-		p_info.query.get_system_info(info);
+		p_info.query.get_system_info(r_out);
 	}
 
-	return info;
+	r_out.system_func = p_exec;
 }
 
 void godex::DynamicSystemInfo::executor(World *p_world, DynamicSystemInfo &p_info) {

--- a/systems/dynamic_system.cpp
+++ b/systems/dynamic_system.cpp
@@ -36,7 +36,7 @@ void godex::DynamicSystemInfo::without_component(uint32_t p_component_id) {
 
 StringName godex::DynamicSystemInfo::for_each_name;
 
-void godex::DynamicSystemInfo::get_info(DynamicSystemInfo &p_info, system_execute p_exec, SystemExeInfo &r_out) {
+void godex::DynamicSystemInfo::get_info(DynamicSystemInfo &p_info, func_system_execute p_exec, SystemExeInfo &r_out) {
 	if (p_info.target_sub_pipeline) {
 		// Sub pipeline execution.
 		// The pipeline must be fully build at this point

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -10,13 +10,18 @@ class World;
 
 namespace godex {
 
+class DynamicSystemInfo;
+
 /// This function register the `DynamicSystemInfo` in a static array (generated
 /// at compile time) and returns a pointer to a function that is able to call
 /// `godex::DynamicSystemInfo::executor()` with the passed `DynamicSystemInfo`.
 uint32_t register_dynamic_system(const DynamicSystemInfo &p_info);
-get_system_exec_info_func get_dynamic_system_get_info(uint32_t p_dynamic_system_id);
+get_system_exec_info_func get_dynamic_system_get_exec_info(uint32_t p_dynamic_system_id);
+DynamicSystemInfo *get_dynamic_system_info(uint32_t p_dynamic_system_id);
 
 /// `DynamicSystemInfo` is a class used to compose a system at runtime.
+/// It's able to execute script systems and sub pipeline systems, in both case
+/// the dependency graph is only known at runtime.
 class DynamicSystemInfo {
 	struct DResource {
 		uint32_t resource_id;

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -8,6 +8,8 @@
 
 class World;
 
+class Pipeline;
+
 namespace godex {
 
 class DynamicSystemInfo;
@@ -29,6 +31,7 @@ class DynamicSystemInfo {
 	};
 
 	Object *target_script = nullptr;
+	Pipeline *target_sub_pipeline = nullptr;
 
 	/// Map used to map the list of Resources to the script.
 	LocalVector<uint32_t> resource_element_map;
@@ -41,14 +44,16 @@ public:
 	DynamicSystemInfo();
 
 	void set_target(Object *p_target);
-	void set_target(system_execute p_target);
+	void set_target(Pipeline *p_pipeline);
+
 	void with_resource(uint32_t p_resource_id, bool p_mutable);
 	void with_component(uint32_t p_component_id, bool p_mutable);
 	void without_component(uint32_t p_component_id);
 
 public:
 	static StringName for_each_name;
-	/// This function is called
+	// TODO instead to return the info consider pass it as reference, to avoid
+	// any copy.
 	static SystemExeInfo get_info(DynamicSystemInfo &p_info, system_execute p_exec);
 	static void executor(World *p_world, DynamicSystemInfo &p_info);
 };

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -18,7 +18,7 @@ class DynamicSystemInfo;
 /// at compile time) and returns a pointer to a function that is able to call
 /// `godex::DynamicSystemInfo::executor()` with the passed `DynamicSystemInfo`.
 uint32_t register_dynamic_system(const DynamicSystemInfo &p_info);
-get_system_exec_info_func get_dynamic_system_get_exec_info(uint32_t p_dynamic_system_id);
+func_get_system_exe_info get_func_dynamic_system_exec_info(uint32_t p_dynamic_system_id);
 DynamicSystemInfo *get_dynamic_system_info(uint32_t p_dynamic_system_id);
 
 /// `DynamicSystemInfo` is a class used to compose a system at runtime.
@@ -53,7 +53,7 @@ public:
 public:
 	static StringName for_each_name;
 
-	static void get_info(DynamicSystemInfo &p_info, system_execute p_exec, SystemExeInfo &r_out);
+	static void get_info(DynamicSystemInfo &p_info, func_system_execute p_exec, SystemExeInfo &r_out);
 	static void executor(World *p_world, DynamicSystemInfo &p_info);
 };
 

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "core/templates/local_vector.h"
 #include "../iterators/dynamic_query.h"
+#include "core/templates/local_vector.h"
 #include "system.h"
 
 class World;
@@ -13,15 +13,18 @@ namespace godex {
 /// This function register the `DynamicSystemInfo` in a static array (generated
 /// at compile time) and returns a pointer to a function that is able to call
 /// `godex::DynamicSystemInfo::executor()` with the passed `DynamicSystemInfo`.
-system_execute register_dynamic_system(const DynamicSystemInfo &p_info);
+uint32_t register_dynamic_system(const DynamicSystemInfo &p_info);
+get_system_exec_info_func get_dynamic_system_get_info(uint32_t p_dynamic_system_id);
 
+/// `DynamicSystemInfo` is a class used to compose a system at runtime.
 class DynamicSystemInfo {
 	struct DResource {
 		uint32_t resource_id;
 		bool is_mutable;
 	};
 
-	Object *target;
+	Object *target_script = nullptr;
+
 	/// Map used to map the list of Resources to the script.
 	LocalVector<uint32_t> resource_element_map;
 	/// Map used to map the list of Components to the script.
@@ -33,15 +36,15 @@ public:
 	DynamicSystemInfo();
 
 	void set_target(Object *p_target);
+	void set_target(system_execute p_target);
 	void with_resource(uint32_t p_resource_id, bool p_mutable);
 	void with_component(uint32_t p_component_id, bool p_mutable);
 	void without_component(uint32_t p_component_id);
 
-	SystemInfo get_system_info() const;
-
 public:
 	static StringName for_each_name;
 	/// This function is called
+	static SystemExeInfo get_info(DynamicSystemInfo &p_info, system_execute p_exec);
 	static void executor(World *p_world, DynamicSystemInfo &p_info);
 };
 

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -52,9 +52,8 @@ public:
 
 public:
 	static StringName for_each_name;
-	// TODO instead to return the info consider pass it as reference, to avoid
-	// any copy.
-	static SystemExeInfo get_info(DynamicSystemInfo &p_info, system_execute p_exec);
+
+	static void get_info(DynamicSystemInfo &p_info, system_execute p_exec, SystemExeInfo &r_out);
 	static void executor(World *p_world, DynamicSystemInfo &p_info);
 };
 

--- a/systems/system.h
+++ b/systems/system.h
@@ -7,17 +7,14 @@
 
 class World;
 
-// TODO rename using `func_` as prefix.
-typedef void (*system_execute)(World *p_world);
+typedef void (*func_system_execute)(World *p_world);
 
-// TODO this goes around, which copy the resource a bunch of times.
-// Do something about??
 struct SystemExeInfo {
 	LocalVector<uint32_t> mutable_components;
 	LocalVector<uint32_t> immutable_components;
 	LocalVector<uint32_t> mutable_resources;
 	LocalVector<uint32_t> immutable_resources;
-	system_execute system_func = nullptr;
+	func_system_execute system_func = nullptr;
 
 	void clear() {
 		mutable_components.clear();
@@ -28,5 +25,4 @@ struct SystemExeInfo {
 	}
 };
 
-// TODO rename using `func_` as prefix.
-typedef void (*get_system_exec_info_func)(SystemExeInfo &);
+typedef void (*func_get_system_exe_info)(SystemExeInfo &);

--- a/systems/system.h
+++ b/systems/system.h
@@ -18,7 +18,15 @@ struct SystemExeInfo {
 	LocalVector<uint32_t> mutable_resources;
 	LocalVector<uint32_t> immutable_resources;
 	system_execute system_func = nullptr;
+
+	void clear() {
+		mutable_components.clear();
+		immutable_components.clear();
+		mutable_resources.clear();
+		immutable_resources.clear();
+		system_func = nullptr;
+	}
 };
 
 // TODO rename using `func_` as prefix.
-typedef SystemExeInfo (*get_system_exec_info_func)();
+typedef void (*get_system_exec_info_func)(SystemExeInfo &);

--- a/systems/system.h
+++ b/systems/system.h
@@ -7,6 +7,7 @@
 
 class World;
 
+// TODO rename using `func_` as prefix.
 typedef void (*system_execute)(World *p_world);
 
 // TODO this goes around, which copy the resource a bunch of times.
@@ -19,4 +20,5 @@ struct SystemExeInfo {
 	system_execute system_func = nullptr;
 };
 
+// TODO rename using `func_` as prefix.
 typedef SystemExeInfo (*get_system_exec_info_func)();

--- a/systems/system.h
+++ b/systems/system.h
@@ -11,10 +11,7 @@ typedef void (*system_execute)(World *p_world);
 
 // TODO this goes around, which copy the resource a bunch of times.
 // Do something about??
-struct SystemInfo {
-	// TODO do I really need the name here?
-	StringName name;
-	String description;
+struct SystemExeInfo {
 	LocalVector<uint32_t> mutable_components;
 	LocalVector<uint32_t> immutable_components;
 	LocalVector<uint32_t> mutable_resources;
@@ -22,4 +19,4 @@ struct SystemInfo {
 	system_execute system_func = nullptr;
 };
 
-typedef SystemInfo (*get_system_info_func)();
+typedef SystemExeInfo (*get_system_exec_info_func)();

--- a/systems/system_builder.h
+++ b/systems/system_builder.h
@@ -21,13 +21,13 @@ template <template <typename...> class Ref, typename... Args>
 struct is_specialization<Ref<Args...>, Ref> : bool_type<true> {};
 
 template <class Q>
-void extract_info(bool_type<true>, SystemInfo &r_info) {
+void extract_info(bool_type<true>, SystemExeInfo &r_info) {
 	// This is a query.
 	Q::get_components(r_info.mutable_components, r_info.immutable_components);
 }
 
 template <class R>
-void extract_info(bool_type<false>, SystemInfo &r_info) {
+void extract_info(bool_type<false>, SystemExeInfo &r_info) {
 	// This is a resource.
 	if (std::is_const<R>()) {
 		r_info.immutable_resources.push_back(R::get_resource_id());
@@ -38,21 +38,21 @@ void extract_info(bool_type<false>, SystemInfo &r_info) {
 
 template <class... Cs>
 struct InfoConstructor {
-	InfoConstructor(SystemInfo &r_info) {}
+	InfoConstructor(SystemExeInfo &r_info) {}
 };
 
 template <class C, class... Cs>
 struct InfoConstructor<C, Cs...> : InfoConstructor<Cs...> {
-	InfoConstructor(SystemInfo &r_info) :
+	InfoConstructor(SystemExeInfo &r_info) :
 			InfoConstructor<Cs...>(r_info) {
 		extract_info<std::remove_reference_t<std::remove_pointer_t<C>>>(is_specialization<std::remove_reference_t<std::remove_pointer_t<C>>, Query>(), r_info);
 	}
 };
 
-/// Creates a SystemInfo, extracting the information from a system function.
+/// Creates a SystemExeInfo, extracting the information from a system function.
 template <class... RCs>
-SystemInfo get_system_info_from_function(void (*system_func)(RCs...)) {
-	SystemInfo si;
+SystemExeInfo get_system_info_from_function(void (*system_func)(RCs...)) {
+	SystemExeInfo si;
 	InfoConstructor<RCs...> a(si);
 	return si;
 }

--- a/systems/system_builder.h
+++ b/systems/system_builder.h
@@ -51,10 +51,8 @@ struct InfoConstructor<C, Cs...> : InfoConstructor<Cs...> {
 
 /// Creates a SystemExeInfo, extracting the information from a system function.
 template <class... RCs>
-SystemExeInfo get_system_info_from_function(void (*system_func)(RCs...)) {
-	SystemExeInfo si;
-	InfoConstructor<RCs...> a(si);
-	return si;
+void get_system_info_from_function(SystemExeInfo &r_info, void (*system_func)(RCs...)) {
+	InfoConstructor<RCs...> a(r_info);
 }
 
 // This is an utility used to convert the type to a reference (`&`).

--- a/tests/test_ecs_pipeline.h
+++ b/tests/test_ecs_pipeline.h
@@ -1,0 +1,103 @@
+#ifndef TEST_ECS_PIPELINE_H
+#define TEST_ECS_PIPELINE_H
+
+#include "tests/test_macros.h"
+
+#include "../components/transform_component.h"
+#include "../ecs.h"
+#include "../pipeline/pipeline.h"
+
+class PipelineTestResource1 : public godex::Resource {
+	RESOURCE(PipelineTestResource1)
+
+public:
+	int a = 10;
+};
+
+class PipelineTestResource2 : public godex::Resource {
+	RESOURCE(PipelineTestResource2)
+
+public:
+	int a = 10;
+};
+
+class PipelineTestComponent1 : public godex::Component {
+	COMPONENT(PipelineTestComponent1, DenseVector)
+};
+
+namespace godex_tests_pipeline {
+
+void system_with_resource(PipelineTestResource1 *test_res) {
+}
+
+void system_with_immutable_resource(const PipelineTestResource2 *test_res) {
+}
+
+void system_with_component(Query<PipelineTestComponent1> &p_query) {
+}
+
+void system_with_immutable_component(Query<const TransformComponent> &p_query) {
+}
+
+TEST_CASE("[Modules][ECS] Test pipeline build.") {
+	ECS::register_resource<PipelineTestResource1>();
+	ECS::register_resource<PipelineTestResource2>();
+	ECS::register_component<PipelineTestComponent1>();
+
+	Pipeline pipeline;
+
+	// Make sure the pipeline is not yet ready.
+	CHECK(pipeline.is_ready() == false);
+
+	pipeline.add_system(system_with_resource);
+
+	// Make sure the pipeline is not yet ready.
+	CHECK(pipeline.is_ready() == false);
+
+	pipeline.build();
+
+	// Make sure the pipeline is now ready.
+	CHECK(pipeline.is_ready());
+
+	pipeline.reset();
+
+	// Make sure the pipeline is not ready again.
+	CHECK(pipeline.is_ready() == false);
+}
+
+TEST_CASE("[Modules][ECS] Test pipeline get_systems_dependencies") {
+	Pipeline pipeline;
+
+	// Add system with MUTABLE `PipelineTestResource1` resource.
+	pipeline.add_system(system_with_resource);
+
+	// Add system with IMMUTABLE `PipelineTestResource2` resource.
+	pipeline.add_system(system_with_immutable_resource);
+
+	// Add system with MUTABLE `PipelineTestComponent1` component.
+	pipeline.add_system(system_with_component);
+
+	// Add system with MUTABLE `TransformComponent` component.
+	pipeline.add_system(system_with_immutable_component);
+
+	pipeline.build();
+
+	SystemExeInfo info;
+	pipeline.get_systems_dependencies(info);
+
+	// Make sure a MUTABLE `PipelineTestResource1` resource is found.
+	CHECK(info.mutable_resources.find(PipelineTestResource1::get_resource_id()) != -1);
+
+	// Make sure an IMMUTABLE `PipelineTestResource2` resource is found.
+	CHECK(info.immutable_resources.find(PipelineTestResource2::get_resource_id()) != -1);
+
+	// Make sure an MUTABLE `PipelineTestComponent1` component is found.
+	CHECK(info.mutable_components.find(PipelineTestComponent1::get_component_id()) != -1);
+
+	// Make sure an IMMUTABLE `TransformComponent` component is found.
+	CHECK(info.immutable_components.find(TransformComponent::get_component_id()) != -1);
+}
+
+} // namespace godex_tests_pipeline
+
+#endif // TEST_ECS_PIPELINE_H

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -15,14 +15,14 @@ class TagTestComponent : public godex::Component {
 	COMPONENT(TagTestComponent, DenseVector)
 };
 
-struct TestSystem1Resource : public godex::Resource {
+class TestSystem1Resource : public godex::Resource {
 	RESOURCE(TestSystem1Resource)
 
 public:
 	int a = 10;
 };
 
-namespace godex_tests {
+namespace godex_tests_system {
 
 void test_system_tag(Query<TransformComponent, const TagTestComponent> &p_query) {
 	while (p_query.is_done() == false) {
@@ -61,6 +61,7 @@ TEST_CASE("[Modules][ECS] Test system and query") {
 
 	Pipeline pipeline;
 	pipeline.add_system(test_system_tag);
+	pipeline.build();
 
 	for (uint32_t i = 0; i < 3; i += 1) {
 		pipeline.dispatch(&world);
@@ -134,7 +135,8 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 	// Create the pipeline.
 	Pipeline pipeline;
 	// Add the system to the pipeline.
-	pipeline.add_registered_system(ECS::get_system_info(system_id));
+	pipeline.add_registered_system(system_id);
+	pipeline.build();
 
 	// Dispatch
 	for (uint32_t i = 0; i < 3; i += 1) {
@@ -175,6 +177,26 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 	}
 }
 
+TEST_CASE("[Modules][ECS] Test dynamic system with sub pipeline C++.") {
+	return;
+	World world;
+
+	EntityID entity_1 = world
+								.create_entity()
+								.with(TransformComponent());
+
+	godex::DynamicSystemInfo dynamic_system_info;
+	dynamic_system_info.with_component(TransformComponent::get_component_id(), true);
+	//dynamic_system_info.set_target(&test_system_tag);
+
+	uint32_t system_id = ECS::register_dynamic_system("TestDynamicSystem.gd", &dynamic_system_info);
+
+	Pipeline pipeline;
+	// Add the system to the pipeline.
+	pipeline.add_registered_system(system_id);
+	pipeline.build();
+}
+
 TEST_CASE("[Modules][ECS] Test system and resource") {
 	ECS::register_resource<TestSystem1Resource>();
 
@@ -191,6 +213,7 @@ TEST_CASE("[Modules][ECS] Test system and resource") {
 		Pipeline pipeline;
 		// Add the system to the pipeline.
 		pipeline.add_system(test_system_with_resource);
+		pipeline.build();
 
 		// Dispatch
 		for (uint32_t i = 0; i < 3; i += 1) {
@@ -211,6 +234,7 @@ TEST_CASE("[Modules][ECS] Test system and resource") {
 		Pipeline pipeline;
 		// Add the system to the pipeline.
 		pipeline.add_system(test_system_with_null_resource);
+		pipeline.build();
 
 		// Dispatch
 		for (uint32_t i = 0; i < 3; i += 1) {
@@ -228,6 +252,6 @@ TEST_CASE("[Modules][ECS] Test system and resource") {
 
 // TODO test resources with C++ and Scripts systems.
 
-} // namespace godex_tests
+} // namespace godex_tests_system
 
 #endif // TEST_ECS_SYSTEM_H


### PR DESCRIPTION
The sub pipeline executor is a special system, that can be created only in C++, which can executes a sub pipeline.

This mechanism is extremely useful when your pipeline may want to execute a set of systems **N** times. These systems can be put in a sub pipeline:
```
Main pipeline
|- System 1
|- System 2
|
|- System with a pipeline
|    |- Sub System 1
|    |- Sub System 2
|    |- Sub System 3
| 
|- System 3
^
```
The sub pipeline can now be processed **N** times, within the main pipeline; **N** can be fixed or can vary.

However, the `sub pipeline` is still a regular pipeline; the systems under it follows the usual rules: They can be executed in parallel if the dependencies allows.

Note that the `sub pipeline` is executed by a system, that even if "special" this `System` remains a `System` which follows the usual `System`s rules: The dependencies of this `System` is the sum of all the `sub pipeline` `System`s dependencies; so the sub pipeline will be dispatched in parallel with the main systems pipeline if possible.

----
The first mechanism that will benefice of this feature is the physics.

We all know that the physics is processed at different (and fixed) ratio compared to the main frame rate; meaning that may needed to process the physics multiple times on the same frame.

For a correct physics execution, in all conditions, is required that all the systems that submit forces to bodies (and generally interact with the physics scene) are processed before the physics engine is stepped.

So, all the systems that interact with the physics are part of a sub pipeline, so when more than 1 physics step per frame is needed, we can still keep obtain a valid physics processing:
```
Main pipeline
|- System 1
|- System 2
|
|- Physics pipeline System
|    |- Move Kinematic Body System
|    |- Push Rigid Body System
|    |- Step the physics scene System
|    |- Get physics events
| 
|- System 3
^
```