### PR TITLE
Added `Query` filters, on both the static and dynamic `Query`.

### DIFF
--- a/iterators/dynamic_query.h
+++ b/iterators/dynamic_query.h
@@ -20,6 +20,7 @@ class DynamicQuery : public Object {
 	bool can_change = true;
 	LocalVector<uint32_t> component_ids;
 	LocalVector<bool> mutability;
+	LocalVector<bool> required;
 	LocalVector<uint32_t> reject_component_ids;
 	LocalVector<AccessComponent> access_components;
 	LocalVector<Storage *> storages;
@@ -35,9 +36,12 @@ public:
 
 	/// Add component.
 	void with_component(uint32_t p_component_id, bool p_mutable = false);
+	void maybe_component(uint32_t p_component_id, bool p_mutable = false);
 
 	/// Excludes this component from the query.
 	void without_component(uint32_t p_component_id);
+
+	void _with_component(uint32_t p_component_id, bool p_mutable = false, bool required = true);
 
 	/// Returns true if this query is valid.
 	bool is_valid() const;

--- a/nodes/ecs_utilities.cpp
+++ b/nodes/ecs_utilities.cpp
@@ -10,6 +10,7 @@
 void System::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("with_resource", "resource_name", "mutability"), &System::with_resource);
 	ClassDB::bind_method(D_METHOD("with_component", "component_name", "mutability"), &System::with_component);
+	ClassDB::bind_method(D_METHOD("maybe_component", "component_name", "mutability"), &System::maybe_component);
 	ClassDB::bind_method(D_METHOD("without_component", "component_name"), &System::without_component);
 
 	BIND_ENUM_CONSTANT(IMMUTABLE);
@@ -52,6 +53,13 @@ void System::with_component(const StringName &p_component, Mutability p_mutabili
 	const godex::component_id id = ECS::get_component_id(p_component);
 	ERR_FAIL_COND_MSG(id == UINT32_MAX, "The component " + p_component + " is unknown.");
 	info->with_component(id, p_mutability == MUTABLE);
+}
+
+void System::maybe_component(const StringName &p_component, Mutability p_mutability) {
+	ERR_FAIL_COND_MSG(info == nullptr, "No info set. This function can be called only within the `_prepare`.");
+	const godex::component_id id = ECS::get_component_id(p_component);
+	ERR_FAIL_COND_MSG(id == UINT32_MAX, "The component " + p_component + " is unknown.");
+	info->maybe_component(id, p_mutability == MUTABLE);
 }
 
 void System::without_component(const StringName &p_component) {

--- a/nodes/ecs_utilities.h
+++ b/nodes/ecs_utilities.h
@@ -34,6 +34,7 @@ public:
 
 	void with_resource(const StringName &p_resource_name, Mutability p_mutability);
 	void with_component(const StringName &p_component_name, Mutability p_mutability);
+	void maybe_component(const StringName &p_component_name, Mutability p_mutability);
 	void without_component(const StringName &p_component_name);
 
 	godex::system_id get_id() const;

--- a/storages/dense_vector.h
+++ b/storages/dense_vector.h
@@ -110,19 +110,25 @@ const godex::Component *DenseVector<T>::get_ptr(EntityID p_entity) const {
 
 template <class T>
 godex::Component *DenseVector<T>::get_ptr(EntityID p_entity) {
+#ifdef DEBUG_ENABLED
 	CRASH_COND_MSG(has(p_entity) == false, "This entity doesn't have anything stored into this storage.");
+#endif
 	return &data[entity_to_data[p_entity]];
 }
 
 template <class T>
 const T &DenseVector<T>::get(EntityID p_entity) const {
+#ifdef DEBUG_ENABLED
 	CRASH_COND_MSG(has(p_entity) == false, "This entity doesn't have anything stored into this storage.");
+#endif
 	return data[entity_to_data[p_entity]];
 }
 
 template <class T>
 T &DenseVector<T>::get(EntityID p_entity) {
+#ifdef DEBUG_ENABLED
 	CRASH_COND_MSG(has(p_entity) == false, "This entity doesn't have anything stored into this storage.");
+#endif
 	return data[entity_to_data[p_entity]];
 }
 

--- a/systems/dynamic_system.h
+++ b/systems/dynamic_system.h
@@ -56,6 +56,7 @@ public:
 
 	void with_resource(uint32_t p_resource_id, bool p_mutable);
 	void with_component(uint32_t p_component_id, bool p_mutable);
+	void maybe_component(uint32_t p_component_id, bool p_mutable);
 	void without_component(uint32_t p_component_id);
 
 	void set_target(func_system_execute_pipeline p_sub_pipeline_execite);

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -34,16 +34,59 @@ TEST_CASE("[Modules][ECS] Test static query") {
 								.with(TransformComponent())
 								.with(TagQueryTestComponent());
 
-	// Test WithoutFilter.
+	// Test `Without` filter.
 	{
-		// Check the API `without_component()`.
-		Query<TransformComponent, WithoutFilter<TagQueryTestComponent>> query(&world);
+		Query<const TransformComponent, Without<TagQueryTestComponent>> query(&world);
 
 		// This query fetches the entity that have only the `TransformComponent`.
 		CHECK(query.is_done() == false);
-		query.get();
-		//auto [transform, _f] = query.get();
-		//CHECK(ABS(transform.transform.origin.z - 23.0) <= CMP_EPSILON);
+		auto [transform, tag] = query.get();
+		CHECK(ABS(transform->transform.origin.z - 23.0) <= CMP_EPSILON);
+		CHECK(query.get_current_entity() == entity_2);
+		CHECK(tag == nullptr);
+
+		query.next();
+
+		// Now it's done
+		CHECK(query.is_done());
+	}
+
+	// Test `Maybe` filter.
+	{
+		Query<const TransformComponent, Maybe<TagQueryTestComponent>> query(&world);
+
+		// This query fetches all entities but return nullptr when
+		// `TagQueryTestComponent` is not set.
+		{
+			// Entity 1
+			CHECK(query.is_done() == false);
+			auto [transform, tag] = query.get();
+			CHECK(query.get_current_entity() == entity_1);
+			CHECK(transform != nullptr);
+			CHECK(tag != nullptr);
+		}
+
+		query.next();
+
+		{
+			// Entity 2
+			CHECK(query.is_done() == false);
+			auto [transform, tag] = query.get();
+			CHECK(query.get_current_entity() == entity_2);
+			CHECK(transform != nullptr);
+			CHECK(tag == nullptr);
+		}
+
+		query.next();
+
+		{
+			// Entity 3
+			CHECK(query.is_done() == false);
+			auto [transform, tag] = query.get();
+			CHECK(query.get_current_entity() == entity_3);
+			CHECK(transform != nullptr);
+			CHECK(tag != nullptr);
+		}
 
 		query.next();
 

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -223,6 +223,39 @@ TEST_CASE("[Modules][ECS] Test dynamic query") {
 
 		query.end();
 	}
+
+	{
+		// Check the API `maybe_component()`.
+		godex::DynamicQuery query;
+		query.with_component(TransformComponent::get_component_id());
+		query.maybe_component(TagQueryTestComponent::get_component_id());
+
+		query.begin(&world);
+
+		// This query fetches the entity that have only the `TransformComponent`.
+		CHECK(query.is_done() == false);
+		CHECK(query.get_current_entity_id() == entity_1);
+		CHECK(query.get_access(0)->__component != nullptr);
+		CHECK(query.get_access(1)->__component != nullptr);
+		query.next();
+
+		CHECK(query.is_done() == false);
+		CHECK(query.get_current_entity_id() == entity_2);
+		CHECK(query.get_access(0)->__component != nullptr);
+		CHECK(query.get_access(1)->__component == nullptr);
+		query.next();
+
+		CHECK(query.is_done() == false);
+		CHECK(query.get_current_entity_id() == entity_3);
+		CHECK(query.get_access(0)->__component != nullptr);
+		CHECK(query.get_access(1)->__component != nullptr);
+		query.next();
+
+		// Now it's done
+		CHECK(query.is_done());
+
+		query.end();
+	}
 }
 
 TEST_CASE("[Modules][ECS] Test dynamic query with dynamic storages.") {

--- a/tests/test_ecs_query.h
+++ b/tests/test_ecs_query.h
@@ -15,9 +15,44 @@ class TagQueryTestComponent : public godex::Component {
 
 namespace godex_tests {
 
-TEST_CASE("[Modules][ECS] Test dynamic query") {
+TEST_CASE("[Modules][ECS] Test static query") {
 	ECS::register_component<TagQueryTestComponent>();
 
+	World world;
+
+	EntityID entity_1 = world
+								.create_entity()
+								.with(TransformComponent())
+								.with(TagQueryTestComponent());
+
+	EntityID entity_2 = world
+								.create_entity()
+								.with(TransformComponent(Transform(Basis(), Vector3(0.0, 0.0, 23.0))));
+
+	EntityID entity_3 = world
+								.create_entity()
+								.with(TransformComponent())
+								.with(TagQueryTestComponent());
+
+	// Test WithoutFilter.
+	{
+		// Check the API `without_component()`.
+		Query<TransformComponent, WithoutFilter<TagQueryTestComponent>> query(&world);
+
+		// This query fetches the entity that have only the `TransformComponent`.
+		CHECK(query.is_done() == false);
+		query.get();
+		//auto [transform, _f] = query.get();
+		//CHECK(ABS(transform.transform.origin.z - 23.0) <= CMP_EPSILON);
+
+		query.next();
+
+		// Now it's done
+		CHECK(query.is_done());
+	}
+}
+
+TEST_CASE("[Modules][ECS] Test dynamic query") {
 	World world;
 
 	EntityID entity_1 = world

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -47,7 +47,7 @@ void test_system_tag(Query<TransformComponent, const TagTestComponent> &p_query)
 	while (p_query.is_done() == false) {
 		auto [transform, component] = p_query.get();
 		transform.transform.origin.x += 100.0;
-		p_query.next_entity();
+		p_query.next();
 	}
 }
 
@@ -218,7 +218,7 @@ void test_system_transform_add_x(Query<TransformComponent> &p_query) {
 	while (p_query.is_done() == false) {
 		auto [transform] = p_query.get();
 		transform.transform.origin.x += 100.0;
-		p_query.next_entity();
+		p_query.next();
 	}
 }
 

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -46,7 +46,7 @@ namespace godex_tests_system {
 void test_system_tag(Query<TransformComponent, const TagTestComponent> &p_query) {
 	while (p_query.is_done() == false) {
 		auto [transform, component] = p_query.get();
-		transform.transform.origin.x += 100.0;
+		transform->transform.origin.x += 100.0;
 		p_query.next();
 	}
 }
@@ -217,7 +217,7 @@ void test_sub_pipeline_execute(World *p_world, Pipeline *p_pipeline) {
 void test_system_transform_add_x(Query<TransformComponent> &p_query) {
 	while (p_query.is_done() == false) {
 		auto [transform] = p_query.get();
-		transform.transform.origin.x += 100.0;
+		transform->transform.origin.x += 100.0;
 		p_query.next();
 	}
 }

--- a/tests/test_ecs_system.h
+++ b/tests/test_ecs_system.h
@@ -137,8 +137,9 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 		code += "\n";
 		code += "func _for_each(transform_com, test_comp):\n";
 		code += "	transform_com.transform.origin.x += 100.0\n";
-		code += "	test_comp.variable_1 += 1\n";
-		code += "	test_comp.variable_2 = Transform()\n";
+		code += "	if test_comp != null:\n";
+		code += "		test_comp.variable_1 += 1\n";
+		code += "		test_comp.variable_2 = Transform()\n";
 		code += "\n";
 
 		ERR_FAIL_COND(build_and_assign_script(&target_obj, code) == false);
@@ -148,7 +149,7 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 	const uint32_t system_id = ECS::register_dynamic_system("TestDynamicSystem.gd");
 	godex::DynamicSystemInfo *dynamic_system_info = ECS::get_dynamic_system_info(system_id);
 	dynamic_system_info->with_component(TransformComponent::get_component_id(), true);
-	dynamic_system_info->with_component(test_dyn_component_id, true);
+	dynamic_system_info->maybe_component(test_dyn_component_id, true);
 	dynamic_system_info->set_target(&target_obj);
 
 	// Create the pipeline.
@@ -173,9 +174,8 @@ TEST_CASE("[Modules][ECS] Test dynamic system using a script.") {
 		// This entity is expected to change.
 		CHECK(ABS(entity_1_origin.x - 300.0) <= CMP_EPSILON);
 
-		// This entity doesn't have a `TagTestComponent` so the systems should not
-		// change it.
-		CHECK(entity_2_origin.x <= CMP_EPSILON);
+		// This entity is expected to change.
+		CHECK(ABS(entity_2_origin.x - 300.0) <= CMP_EPSILON);
 
 		// This entity is expected to change.
 		CHECK(ABS(entity_3_origin.x - 300.0) <= CMP_EPSILON);


### PR DESCRIPTION
Added `Query` filters, on both the static and dynamic `Query`.
Now is possible to specify the filters `Without` and `Maybe` on the query.

### Static query:
```c++
Query<const TransformComponent, BulletComponent, Maybe<const Critical>, Without<UnactiveComponent>> query(&world);
```

### GDScript
```gdscript
func _prepare():
    with_component("TransformComponent", IMMUTABLE)
    with_component("BulletComponent", MUTABLE)
    maybe_component("Critical", IMMUTABLE)
    without_component("TransformComponent")

func _for_each(transform, bullet, critical):
    pass
```
